### PR TITLE
Exclude tests from release

### DIFF
--- a/NURFG.csproj
+++ b/NURFG.csproj
@@ -5,4 +5,8 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.2" />
   </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)'!='DEBUG'">
+    <Compile Remove="Tests\**" />
+    <EmbeddedResource Remove="Tests\**" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
It is relatively easy to exclude tests from the release build of the game