### PR TITLE
Godot 4.1 update

### DIFF
--- a/NURFG.csproj
+++ b/NURFG.csproj
@@ -1,14 +1,11 @@
-<Project Sdk="Godot.NET.Sdk/3.3.0">
-
+<Project Sdk="Godot.NET.Sdk/4.1.1">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
-
   <!-- NuGet packages used only by tests belong here -->
   <ItemGroup Condition="'$(Configuration)'=='DEBUG'">
     <PackageReference Include="NUnit" Version="3.13.2" />
   </ItemGroup>
-
   <!-- Exclude tests from the release build, so they don't ship with the game. -->
   <ItemGroup Condition="'$(Configuration)'!='DEBUG'">
     <Compile Remove="Tests\**" />

--- a/Tests/SimpleTest.cs
+++ b/Tests/SimpleTest.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 
 namespace NURFG.Tests
 {
-    public class SimpleTest
+    public partial class SimpleTest
     {
         [Test]
         public void This_Test_Passes()

--- a/addons/NURFG/EditorWidget/TestRunnerDock.cs
+++ b/addons/NURFG/EditorWidget/TestRunnerDock.cs
@@ -10,7 +10,7 @@ using NUnit.Framework.Interfaces;
 namespace NURFG
 {
     [Tool]
-    public class TestRunnerDock : Control
+    public partial class TestRunnerDock : Control
     {
         private FrameworkController _nunit;
 
@@ -27,20 +27,20 @@ namespace NURFG
             InitializeNUnitIfNeeded();
 
             // Connect controls
-            _refreshButton = (Button)FindNode("RefreshButton");
-            _refreshButton.Connect("pressed", this, nameof(RefreshButton_Click));
+            _refreshButton = (Button)GetNode("HBoxContainer/RefreshButton");
+            _refreshButton.Connect("pressed", Callable.From(() => RefreshButton_Click()));
 
-            _runButton = (Button)FindNode("RunButton");
-            _runButton.Connect("pressed", this, nameof(RunButton_Click));
+            _runButton = (Button)GetNode("HBoxContainer/RunButton");
+            _runButton.Connect("pressed", Callable.From(() => RunButton_Click()));
 
-            _resultTree = (Tree)FindNode("ResultTree");
-            _resultTree.Connect("item_selected", this, nameof(TestResultTree_ItemSelected));
-            _resultTree.Connect("item_activated", this, nameof(TestResultTree_ItemActivated));
+            _resultTree = (Tree)GetNode("VSplitContainer/ResultTree");
+            _resultTree.Connect("item_selected", Callable.From(() => TestResultTree_ItemSelected()));
+            _resultTree.Connect("item_activated", Callable.From(() => TestResultTree_ItemActivated()));
 
-            _testOutputLabel = (RichTextLabel)FindNode("TestOutputLabel");
+            _testOutputLabel = (RichTextLabel)GetNode("VSplitContainer/TestOutputLabel");
         }
 
-        public override void _Process(float delta)
+        public override void _Process(double delta)
         {
             base._Process(delta);
 
@@ -68,7 +68,7 @@ namespace NURFG
         {
             _testTreeItems.Clear();
             _resultTree.Clear();
-            
+
             CreateTreeItemForTest(_nunit.Runner.LoadedTest);
 
             foreach (var test in _testTreeItems.Keys)
@@ -159,7 +159,7 @@ namespace NURFG
 
             if (!test.IsSuite)
                 return $"{icon} {test.Name}";
-            
+
             if (!_testResults.ContainsKey(test) || _testResults[test] == null)
                 return $"{icon} {test.Name} ({test.TestCaseCount} found)";
 
@@ -196,7 +196,7 @@ namespace NURFG
             // Tests that haven't been run do not have an entry in _testResults.
             if (!_testResults.ContainsKey(test))
                 return TestState.NotRun;
-            
+
             // Tests that are in progress have a null entry in _testResults
             else if (_testResults[test] == null)
                 return TestState.InProgress;
@@ -235,7 +235,7 @@ namespace NURFG
                 case TestState.Failed: return "[FAILED]";
                 case TestState.Inconclusive: return "?";
                 case TestState.Warning: return "[WARN]";
-                
+
                 default: return $"[{state.ToString().ToUpper()}]";
             }
         }
@@ -284,12 +284,12 @@ namespace NURFG
         {
             if (_testTreeItems.ContainsKey(test))
                 return;
-            
+
             // Create a tree item for this test
             var parentTreeItem = test.Parent == null
                 ? null
                 : _testTreeItems[test.Parent];
-                    
+
             var treeItem = _resultTree.CreateItem(parentTreeItem);
             _testTreeItems[test] = treeItem;
 
@@ -297,7 +297,7 @@ namespace NURFG
             foreach (var child in test.Tests)
                 CreateTreeItemForTest(child);
         }
-    
+
         private ITest GetTestFromTreeItem(TreeItem treeItem)
         {
             return _testTreeItems
@@ -306,6 +306,5 @@ namespace NURFG
                 .FirstOrDefault();
         }
     }
-
 }
 #endif

--- a/addons/NURFG/Plugin.cs
+++ b/addons/NURFG/Plugin.cs
@@ -5,13 +5,13 @@ using System;
 namespace NURFG
 {
     [Tool]
-    public class Plugin : EditorPlugin
+    public partial class Plugin : EditorPlugin
     {
         private Control _dock;
 
         public override void _EnterTree()
         {
-            _dock = (Control)GD.Load<PackedScene>("addons/NURFG/EditorWidget/TestRunnerDock.tscn").Instance();
+            _dock = (Control)GD.Load<PackedScene>("addons/NURFG/EditorWidget/TestRunnerDock.tscn").Instantiate();
             AddControlToDock(DockSlot.RightBl, _dock);
         }
 

--- a/default_env.tres
+++ b/default_env.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Environment" load_steps=2 format=2]
 
-[sub_resource type="ProceduralSky" id=1]
+[sub_resource type="Sky" id=1]
 
 [resource]
 background_mode = 2

--- a/icon.png.import
+++ b/icon.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
+type="CompressedTexture2D"
+uid="uid://dorpw16nbspvm"
+path="res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,26 +11,24 @@ metadata={
 [deps]
 
 source_file="res://icon.png"
-dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_files=["res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
 process/normal_map_invert_y=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/project.godot
+++ b/project.godot
@@ -6,16 +6,21 @@
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
 
-config_version=4
+config_version=5
 
 [application]
 
 config/name="NURFG"
+config/features=PackedStringArray("4.1", "C#")
 config/icon="res://icon.png"
+
+[dotnet]
+
+project/assembly_name="NURFG"
 
 [editor_plugins]
 
-enabled=PoolStringArray( "res://addons/NURFG/plugin.cfg" )
+enabled=PackedStringArray("res://addons/NURFG/plugin.cfg")
 
 [physics]
 
@@ -23,4 +28,4 @@ common/enable_pause_aware_picking=true
 
 [rendering]
 
-environment/default_environment="res://default_env.tres"
+environment/defaults/default_environment="res://default_env.tres"


### PR DESCRIPTION
Updated to work with Godot 4.1 version, it introduces a new error that spams the Output but doesn't do anything: 

`Caller thread can't call this function in this node (/root/@EditorNode@17664/@Control@697/@Panel@698/@VBoxContainer@706/@HSplitContainer@709/@HSplitContainer@717/@HSplitContainer@725/@HSplitContainer@730/@VSplitContainer@732/@TabContainer@736/NUnit Runner/VSplitContainer/ResultTree). Use call_deferred() or call_thread_group() instead.`